### PR TITLE
find system lua with pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ compiletest_rs = { version = "0.3", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }
+pkg-config = "0.3.11"
 
 [dev-dependencies]
 rustyline = "1.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "builtin-lua")]
 extern crate cc;
 
+#[cfg(not(feature = "builtin-lua"))]
+extern crate pkg_config;
+
 fn main() {
     #[cfg(feature = "builtin-lua")]
     {
@@ -61,5 +64,9 @@ fn main() {
             .file("lua/lvm.c")
             .file("lua/lzio.c")
             .compile("liblua5.3.a");
+    }
+    #[cfg(not(feature = "builtin-lua"))]
+    {
+        pkg_config::Config::new().atleast_version("5.3").probe("lua").unwrap();
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -78,7 +78,6 @@ pub const LUA_GCSETPAUSE: c_int = 6;
 pub const LUA_GCSETSTEPMUL: c_int = 7;
 pub const LUA_GCISRUNNING: c_int = 9;
 
-#[link(name = "lua5.3")]
 extern "C" {
     pub fn lua_newstate(alloc: lua_Alloc, ud: *mut c_void) -> *mut lua_State;
     pub fn lua_close(state: *mut lua_State);


### PR DESCRIPTION
Hi,

I'm working on a project that requires to use the system lua and I'm having some problems building it because of linker errors.

The file `src/ffi.rs` adds the linker flag `-llua5.3` to the build, but the linker cannot find this on my system (I am using Fedora 28). The correct linker flags on my system are:

```
$ pkg-config --libs lua        
-llua -lm -ldl
```

So I removed the `#[link]` attribute from the ffi source file and it seems to still build fine (I think it gets automatically added in that build declaration in `build.rs` but I'm not sure) so the hardcoded `-llua5.3` linker argument does not get passed.

Then I added the pkg-config crate which adds all the correct flags for my system lua hopefully in a way that is portable.

I'm new to Rust, so I don't know if I did this correctly. Let me know if there is a different approach that will work better.

Thanks.