### PR TITLE
Support for hooks (viewing only)

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -17,6 +17,7 @@ pub type lua_KContext = *mut c_void;
 pub type lua_KFunction =
     unsafe extern "C" fn(state: *mut lua_State, status: c_int, ctx: lua_KContext) -> c_int;
 pub type lua_CFunction = unsafe extern "C" fn(state: *mut lua_State) -> c_int;
+pub type lua_Hook = unsafe extern "C" fn(state: *mut lua_State, ar: *mut lua_Debug);
 
 #[repr(C)]
 pub struct lua_Debug {
@@ -77,6 +78,11 @@ pub const LUA_GCSTEP: c_int = 5;
 pub const LUA_GCSETPAUSE: c_int = 6;
 pub const LUA_GCSETSTEPMUL: c_int = 7;
 pub const LUA_GCISRUNNING: c_int = 9;
+
+pub const LUA_MASKCALL: c_int = 1;
+pub const LUA_MASKRET: c_int = 2;
+pub const LUA_MASKLINE: c_int = 4;
+pub const LUA_MASKCOUNT: c_int = 8;
 
 extern "C" {
     pub fn lua_newstate(alloc: lua_Alloc, ud: *mut c_void) -> *mut lua_State;
@@ -162,6 +168,8 @@ extern "C" {
     pub fn lua_atpanic(state: *mut lua_State, panic: lua_CFunction) -> lua_CFunction;
     pub fn lua_gc(state: *mut lua_State, what: c_int, data: c_int) -> c_int;
     pub fn lua_getinfo(state: *mut lua_State, what: *const c_char, ar: *mut lua_Debug) -> c_int;
+
+    pub fn lua_sethook(state: *mut lua_State, f: Option<lua_Hook>, mask: c_int, count: c_int);
 
     pub fn luaopen_base(state: *mut lua_State) -> c_int;
     pub fn luaopen_coroutine(state: *mut lua_State) -> c_int;

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -152,14 +152,15 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             _unused: ()
         };
 
-        let cb = (&*extra_data(state)).hook_callback
+        let cb = (extra_data(state)).hook_callback
             .as_ref()
+            .map(|rc| rc.clone())
             .expect("rlua internal error: no hooks previously set; this is a bug");
         (&mut *match cb.try_borrow_mut() {
             Ok(b) => b,
             Err(_) => rlua_panic!("Lua should not allow hooks to be called within another hook;\
                 please make an issue")
-        })(lua, &debug)
+        })(&lua, &debug)
     });
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -6,6 +6,12 @@ use lua::extra_data;
 use util::callback_error;
 
 /// Contains information about the running code at the moments specified when setting the hook.
+/// Each field is described in the [Lua 5.3 documentaton][lua_doc].
+///
+/// Depending on when the hook is called, some fields might not be available. In these cases,
+/// integers and booleans might not be valid and/or strings are set to `None`.
+///
+/// [lua_doc]: https://www.lua.org/manual/5.3/manual.html#lua_Debug
 #[derive(Clone, Debug)]
 pub struct Debug<'a> {
     pub name: Option<Cow<'a, str>>,
@@ -23,7 +29,7 @@ pub struct Debug<'a> {
 }
 
 impl<'a> Debug<'a> {
-    /// Constructs a new `Debug` structure that is not associated with a Lua debug structure. It
+    /// Construct a new `Debug` structure that is not associated with a Lua debug structure. It
     /// involves some string copying.
     pub fn to_owned(&'a self) -> Debug<'static> {
         Debug {
@@ -43,7 +49,7 @@ impl<'a> Debug<'a> {
     }
 }
 
-/// Indicates in which circumstances the hook should be called by Lua.
+/// Indicate in which circumstances the hook should be called by Lua.
 pub struct HookOptions {
     /// Before a function call.
     pub calls: bool,
@@ -53,13 +59,13 @@ pub struct HookOptions {
     pub lines: bool,
     /// After a certain amount of instructions specified by `count`.
     pub after_counts: bool,
-    /// Indicates how many instructions to execute before calling the hook. Only effective when
+    /// Specify how many instructions to execute before calling the hook. Only effective when
     /// `after_counts` is set to true.
     pub count: u32
 }
 
 impl HookOptions {
-    // Computes the mask to pass to `lua_sethook`.
+    // Compute the mask to pass to `lua_sethook`.
     pub(crate) fn mask(&self) -> c_int {
         let mut mask: c_int = 0;
         if self.calls { mask |= ffi::LUA_MASKCALL }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -133,8 +133,6 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             rlua_panic!("lua_getinfo failed")
         }
 
-        let extra = &mut *extra_data(state);
-
         let debug = Debug {
             name: ptr_to_str((*ar).name as *const i8),
             namewhat: ptr_to_str((*ar).namewhat as *const i8),
@@ -153,10 +151,10 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             _unused: ()
         };
 
-        let cb = extra.hook_callback
-            .as_mut()
+        let cb = (&*extra_data(state)).hook_callback
+            .as_ref()
             .expect("rlua internal error: no hooks previously set; this is a bug");
-        cb(&debug)
+        (*cb)(&debug)
     });
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -70,7 +70,7 @@ impl<'a> Debug<'a> {
 /// # use rlua::HookTriggers;
 /// # fn main() {
 /// let triggers = HookTriggers {
-///     after_counts: Some(1), ..Default::default()
+///     on_every_nth_instruction: Some(1), ..Default::default()
 /// };
 /// # let _ = triggers;
 /// # }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,11 +1,24 @@
-use libc::c_int;
+use std::{slice, ptr, mem, str};
+use libc::{self, c_int};
 use ffi::{self, lua_State, lua_Debug};
 use lua::extra_data;
 use util::callback_error;
 
 /// Contains information about the running code at the moments specified when setting the hook.
-pub struct Debug {
-    pub curr_line: u32
+#[derive(Clone, Debug)]
+pub struct Debug<'a> {
+    pub name: Option<&'a str>,
+    pub namewhat: Option<&'a str>,
+    pub what: Option<&'a str>,
+    pub source: Option<&'a str>,
+    pub curr_line: u32,
+    pub line_defined: u32,
+    pub last_line_defined: u32,
+    pub num_ups: u32,
+    pub num_params: u32,
+    pub is_vararg: bool,
+    pub is_tailcall: bool,
+    pub short_src: Option<&'a str>
 }
 
 /// Indicates in which circumstances the hook should be called by Lua.
@@ -50,10 +63,27 @@ impl Default for HookOptions {
 /// This callback is passed to `lua_sethook` and gets called whenever debug information is received.
 pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_Debug) {
     callback_error(state, || {
+        if ffi::lua_getinfo(state, cstr!("nSltu"), ar) == 0 {
+            rlua_panic!("lua_getinfo failed")
+        }
+
         let extra = &mut *extra_data(state);
 
         let debug = Debug {
-            curr_line: (*ar).currentline as u32
+            name: ptr_to_str((*ar).name as *const i8),
+            namewhat: ptr_to_str((*ar).namewhat as *const i8),
+            what: ptr_to_str((*ar).what as *const i8),
+            source: ptr_to_str((*ar).source as *const i8),
+            curr_line: (*ar).currentline as u32,
+            line_defined: (*ar).linedefined as u32,
+            last_line_defined: (*ar).lastlinedefined as u32,
+            num_ups: (*ar).nups as u32,
+            num_params: (*ar).nparams as u32,
+            is_vararg: (*ar).isvararg == 1,
+            is_tailcall: (*ar).istailcall == 1,
+            short_src: str::from_utf8(mem::transmute((*ar).short_src.as_ref()))
+                .and_then(|r| Ok(Some(r)))
+                .unwrap_or(None)
         };
 
         let cb = extra.hook_callback
@@ -61,4 +91,13 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             .expect("no hooks previously set; this is a bug");
         cb(&debug)
     });
+}
+
+unsafe fn ptr_to_str<'a>(input: *const i8) -> Option<&'a str> {
+    if input == ptr::null() || ptr::read(input) == 0 {
+        return None;
+    }
+    let len = libc::strlen(input) as usize;
+    let input = slice::from_raw_parts(input as *const u8, len);
+    str::from_utf8(input).and_then(|r| Ok(Some(r.trim_right()))).unwrap_or(None)
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,6 +1,5 @@
 use std::{slice, ptr, mem, str};
 use std::borrow::Cow;
-use std::sync::atomic::Ordering;
 use libc::{self, c_int};
 use ffi::{self, lua_State, lua_Debug};
 use lua::extra_data;
@@ -129,7 +128,7 @@ impl Default for HookTriggers {
 
 /// This callback is passed to `lua_sethook` and gets called whenever debug information is received.
 pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_Debug) {
-    let result = callback_error(state, || {
+    callback_error(state, || {
         if ffi::lua_getinfo(state, cstr!("nSltu"), ar) == 0 {
             rlua_panic!("lua_getinfo failed")
         }
@@ -152,14 +151,11 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             _unused: ()
         };
 
-        (&mut *extra_data(state)).in_hook.store(true, Ordering::Relaxed);
         let cb = (&*extra_data(state)).hook_callback
             .as_ref()
             .expect("rlua internal error: no hooks previously set; this is a bug");
         (*cb)(&debug)
     });
-    (&mut *extra_data(state)).in_hook.store(false, Ordering::Relaxed);
-    result
 }
 
 unsafe fn ptr_to_str<'a>(input: *const i8) -> Option<Cow<'a, str>> {

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,64 @@
+use libc::c_int;
+use ffi::{self, lua_State, lua_Debug};
+use lua::extra_data;
+use util::callback_error;
+
+/// Contains information about the running code at the moments specified when setting the hook.
+pub struct Debug {
+    pub curr_line: u32
+}
+
+/// Indicates in which circumstances the hook should be called by Lua.
+pub struct HookOptions {
+    /// Before a function call.
+    pub calls: bool,
+    /// When Lua returns from a function.
+    pub returns: bool,
+    /// Before executing a new line, or returning from a function call.
+    pub lines: bool,
+    /// After a certain amount of instructions specified by `count`.
+    pub after_counts: bool,
+    /// Indicates how many instructions to execute before calling the hook. Only effective when
+    /// `after_counts` is set to true.
+    pub count: u32
+}
+
+impl HookOptions {
+    // Computes the mask to pass to `lua_sethook`.
+    pub(crate) fn mask(&self) -> c_int {
+        let mut mask: c_int = 0;
+        if self.calls { mask |= ffi::LUA_MASKCALL }
+        if self.returns { mask |= ffi::LUA_MASKRET }
+        if self.lines { mask |= ffi::LUA_MASKLINE }
+        if self.after_counts { mask |= ffi::LUA_MASKCOUNT }
+        mask
+    }
+}
+
+impl Default for HookOptions {
+    fn default() -> Self {
+        HookOptions {
+            calls: false,
+            returns: false,
+            lines: false,
+            after_counts: false,
+            count: 0
+        }
+    }
+}
+
+// This callback is passed to `lua_sethook` and gets called whenever debug information is received.
+pub unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_Debug) {
+    callback_error(state, || {
+        let extra = &*extra_data(state);
+
+        let debug = Debug {
+            curr_line: (*ar).currentline as u32
+        };
+
+        let cb = extra.hook_callback
+            .as_ref()
+            .expect("no hooks previously set; this is a bug");
+        cb(&debug)
+    });
+}

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -133,7 +133,7 @@ pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_De
             rlua_panic!("lua_getinfo failed")
         }
 
-        let lua = Lua::from_state(state, false);
+        let lua = Lua::from_state(state);
         let debug = Debug {
             name: ptr_to_str((*ar).name as *const i8),
             namewhat: ptr_to_str((*ar).namewhat as *const i8),

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -147,6 +147,7 @@ pub struct Stack {
 /// # let _ = triggers;
 /// # }
 /// ```
+#[derive(Clone, Display)]
 pub struct HookTriggers {
     /// Before a function call.
     pub on_calls: bool,
@@ -184,17 +185,6 @@ impl HookTriggers {
     /// returned.
     pub(crate) fn count(&self) -> c_int {
         self.every_nth_instruction.unwrap_or(0) as c_int
-    }
-}
-
-impl Default for HookTriggers {
-    fn default() -> Self {
-        HookTriggers {
-            on_calls: false,
-            on_returns: false,
-            every_line: false,
-            every_nth_instruction: None
-        }
     }
 }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -47,17 +47,17 @@ impl Default for HookOptions {
     }
 }
 
-// This callback is passed to `lua_sethook` and gets called whenever debug information is received.
-pub unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_Debug) {
+/// This callback is passed to `lua_sethook` and gets called whenever debug information is received.
+pub(crate) unsafe extern "C" fn hook_proc(state: *mut lua_State, ar: *mut lua_Debug) {
     callback_error(state, || {
-        let extra = &*extra_data(state);
+        let extra = &mut *extra_data(state);
 
         let debug = Debug {
             curr_line: (*ar).currentline as u32
         };
 
         let cb = extra.hook_callback
-            .as_ref()
+            .as_mut()
             .expect("no hooks previously set; this is a bug");
         cb(&debug)
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,5 +73,6 @@ pub use thread::{Thread, ThreadStatus};
 pub use types::{Integer, LightUserData, Number, RegistryKey};
 pub use userdata::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 pub use value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
+pub use hook::{HookOptions, Debug};
 
 pub mod prelude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,20 @@
 //! The [`UserData`] trait can be implemented by user-defined types to make them available to Lua.
 //! Methods and operators to be used from Lua can be added using the [`UserDataMethods`] API.
 //!
+//! # Hooks
+//!
+//! The [`Lua`] struct provides you with a [`hook`] setter method which you may call to gain
+//! information about your script or simply to control it.
+//!
+//! You are safe to use an `FnMut` function as Lua will never call your hook if you are executing
+//! more Lua code within the hook. You have full access to Lua from it.
+//!
 //! [Lua programming language]: https://www.lua.org/
 //! [`Lua`]: struct.Lua.html
 //! [executing]: struct.Lua.html#method.exec
 //! [evaluating]: struct.Lua.html#method.eval
 //! [globals]: struct.Lua.html#method.globals
+//! [hook]: struct.Lua.html#method.set_hook
 //! [`ToLua`]: trait.ToLua.html
 //! [`FromLua`]: trait.FromLua.html
 //! [`ToLuaMulti`]: trait.ToLuaMulti.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,6 @@ pub use thread::{Thread, ThreadStatus};
 pub use types::{Integer, LightUserData, Number, RegistryKey};
 pub use userdata::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 pub use value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
-pub use hook::{HookOptions, Debug};
+pub use hook::{HookTriggers, Debug};
 
 pub mod prelude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ mod types;
 mod userdata;
 mod util;
 mod value;
+mod hook;
 
 pub use error::{Error, ExternalError, ExternalResult, Result};
 pub use function::Function;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Hooks
 //!
-//! The [`Lua`] struct provides you with a [`hook`] setter method which you may call to gain
+//! The [`Lua`] struct provides you with a [hook] setter method which you may call to gain
 //! information about your script or simply to control it.
 //!
 //! You are safe to use an `FnMut` function as Lua will never call your hook if you are executing
@@ -69,7 +69,7 @@ mod types;
 mod userdata;
 mod util;
 mod value;
-mod hook;
+pub mod hook;
 
 pub use error::{Error, ExternalError, ExternalResult, Result};
 pub use function::Function;
@@ -82,6 +82,6 @@ pub use thread::{Thread, ThreadStatus};
 pub use types::{Integer, LightUserData, Number, RegistryKey};
 pub use userdata::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 pub use value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
-pub use hook::{HookTriggers, Debug};
+pub use hook::HookTriggers;
 
 pub mod prelude;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -26,7 +26,7 @@ use util::{
     userdata_destructor, StackGuard,
 };
 use value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
-use hook::{Debug, HookOptions, hook_proc};
+use hook::{Debug, HookTriggers, hook_proc};
 
 /// Top level Lua struct which holds the Lua state itself.
 pub struct Lua {
@@ -636,7 +636,7 @@ impl Lua {
     ///
     /// ```
     /// # extern crate rlua;
-    /// # use rlua::{Lua, HookOptions, Debug};
+    /// # use rlua::{Lua, HookTriggers, Debug};
     /// # fn main() {
     /// let code = r#"local x = 2 + 3
     /// local y = x * 63
@@ -644,7 +644,7 @@ impl Lua {
     /// "#;
     ///
     /// let lua = Lua::new();
-    /// lua.set_hook(HookOptions {
+    /// lua.set_hook(HookTriggers {
     ///     lines: true, ..Default::default()
     /// }, |debug: &Debug| {
     ///     println!("line {}", debug.curr_line);
@@ -655,28 +655,14 @@ impl Lua {
     /// ```
     pub fn set_hook<F>(
         &self,
-        options: HookOptions,
-        callback: F)
-    where
-        F: 'static + Send + Fn(&Debug) -> Result<()>
-    {
-        self.set_mut_hook(options, callback)
-    }
-
-    /// Set a function for Lua the same way as [`set_hook`], but allows the use of a mutable
-    /// function. The behavior is the same otherwise.
-    ///
-    /// [`set_hook`]: #method.set_hook
-    pub fn set_mut_hook<F>(
-        &self,
-        options: HookOptions,
+        options: HookTriggers,
         callback: F)
     where
         F: 'static + Send + FnMut(&Debug) -> Result<()>
     {
         unsafe {
             (*extra_data(self.state)).hook_callback = Some(Box::new(callback));
-            ffi::lua_sethook(self.state, Some(hook_proc), options.mask() as _, options.count as _);
+            ffi::lua_sethook(self.state, Some(hook_proc), options.mask(), options.count());
         }
     }
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -626,9 +626,13 @@ impl Lua {
         }
     }
 
-    /// Set a function for Lua to call on conditions configured by `options`. This function will
+    /// Set a function for Lua to call on conditions configured by `triggers`. This function will
     /// always succeed, but the hook may raise an error to be reported back to the caller when
     /// running Lua code.
+    ///
+    /// You may use this functionality for a few reasons. You may limit yourself to viewing the
+    /// information or react to certain events. However, you can also use it to limit for how long
+    /// the script will run.
     ///
     /// # Example
     ///
@@ -655,14 +659,14 @@ impl Lua {
     /// ```
     pub fn set_hook<F>(
         &self,
-        options: HookTriggers,
+        triggers: HookTriggers,
         callback: F)
     where
         F: 'static + Send + FnMut(&Debug) -> Result<()>
     {
         unsafe {
             (*extra_data(self.state)).hook_callback = Some(Box::new(callback));
-            ffi::lua_sethook(self.state, Some(hook_proc), options.mask(), options.count());
+            ffi::lua_sethook(self.state, Some(hook_proc), triggers.mask(), triggers.count());
         }
     }
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -663,7 +663,7 @@ impl Lua {
     /// lua.set_hook(HookTriggers {
     ///     every_line: true, ..Default::default()
     /// }, |_lua: &Lua, debug: &Debug| {
-    ///     println!("line {}", debug.curr_line);
+    ///     println!("line {}", debug.curr_line());
     ///     Ok(())
     /// });
     /// let _ = lua.exec::<_, ()>(code, None);

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -649,7 +649,7 @@ impl Lua {
     ///
     /// let lua = Lua::new();
     /// lua.set_hook(HookTriggers {
-    ///     lines: true, ..Default::default()
+    ///     each_line: true, ..Default::default()
     /// }, |debug: &Debug| {
     ///     println!("line {}", debug.curr_line);
     ///     Ok(())

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -626,12 +626,14 @@ impl Lua {
         }
     }
 
-    /// Sets a function for Lua to call on conditions specified by the function. This function will
-    /// always succeed, but its hook can raise an error if necessary.
+    /// Set a function for Lua to call on conditions configured by `options`. This function will
+    /// always succeed, but the hook may raise an error to be reported back to the caller when
+    /// running Lua code.
     ///
     /// # Example
     ///
-    /// Shows each line of code being executed by the Lua interpreter.
+    /// Shows each line number of code being executed by the Lua interpreter.
+    ///
     /// ```
     /// # extern crate rlua;
     /// # use rlua::{Lua, HookOptions, Debug};
@@ -661,7 +663,7 @@ impl Lua {
         self.set_mut_hook(options, callback)
     }
 
-    /// Sets a function for Lua the same way as [`set_hook`], but allows the use of a mutable
+    /// Set a function for Lua the same way as [`set_hook`], but allows the use of a mutable
     /// function. The behavior is the same otherwise.
     ///
     /// [`set_hook`]: #method.set_hook
@@ -678,7 +680,7 @@ impl Lua {
         }
     }
 
-    /// Removes any hook previously set by `set_hook`. This function has no effect if no hook was
+    /// Remove any hook previously set by `set_hook`. This function has no effect if no hook was
     /// set.
     pub fn remove_hook(&self) {
         unsafe {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -632,8 +632,25 @@ impl Lua {
     /// # Example
     ///
     /// Shows each line of code being executed by the Lua interpreter.
-    /// TODO: When finished.
+    /// ```
+    /// # extern crate rlua;
+    /// # use rlua::{Lua, HookOptions, Debug};
+    /// # fn main() {
+    /// let code = r#"local x = 2 + 3
+    /// local y = x * 63
+    /// local z = string.len(x..", "..y)
+    /// "#;
     ///
+    /// let lua = Lua::new();
+    /// lua.set_hook(HookOptions {
+    ///     lines: true, ..Default::default()
+    /// }, |debug: &Debug| {
+    ///     println!("line {}", debug.curr_line);
+    ///     Ok(())
+    /// });
+    /// let _ = lua.exec::<_, ()>(code, None);
+    /// # }
+    /// ```
     pub fn set_hook<F>(
         &self,
         options: HookOptions,

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -8,7 +8,6 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::string::String as StdString;
 use std::sync::{Arc, Mutex};
 use std::{mem, ptr, str};
-use std::sync::atomic::{Ordering, AtomicBool};
 
 use libc;
 
@@ -84,7 +83,7 @@ impl Lua {
     where
         S: ?Sized + AsRef<[u8]>,
     {
-        self.execution_scope(|| unsafe {
+        unsafe {
             let _sg = StackGuard::new(self.state);
             assert_stack(self.state, 1);
             let source = source.as_ref();
@@ -113,7 +112,7 @@ impl Lua {
                 ffi::LUA_OK => Ok(Function(self.pop_ref())),
                 err => Err(pop_error(self.state, err)),
             }
-        })
+        }
     }
 
     /// Execute a chunk of Lua code.
@@ -131,7 +130,7 @@ impl Lua {
         S: ?Sized + AsRef<[u8]>,
         R: FromLuaMulti<'lua>,
     {
-        self.execution_scope(|| self.load(source, name)?.call(()))
+        self.load(source, name)?.call(())
     }
 
     /// Evaluate the given expression or chunk inside this Lua state.
@@ -148,11 +147,9 @@ impl Lua {
         // actual lua repl does.
         let mut return_source = "return ".as_bytes().to_vec();
         return_source.extend(source.as_ref());
-        self.execution_scope(||
-            self.load(&return_source, name)
-                .or_else(|_| self.load(source, name))?
-                .call(())
-        )
+        self.load(&return_source, name)
+            .or_else(|_| self.load(source, name))?
+            .call(())
     }
 
     /// Create and return an interned Lua string.  Lua strings can be arbitrary [u8] data including
@@ -976,21 +973,6 @@ impl Lua {
 
         Ok(AnyUserData(self.pop_ref()))
     }
-
-    // Any code that desires to tell Lua to execute code should go through this function. It will
-    // panic if it is running within a hook.
-    fn execution_scope<F, R>(&self, proc: F) -> Result<R>
-    where
-        F: FnOnce() -> Result<R>,
-        R: Sized
-    {
-        let in_hook = (unsafe { &*extra_data(self.state) }).in_hook.load(Ordering::Relaxed);
-        if in_hook {
-            rlua_panic!("attempted to run code within a hook")
-        } else {
-            proc()
-        }
-    }
 }
 
 // Data associated with the main lua_State via lua_getextraspace.
@@ -1003,9 +985,7 @@ pub(crate) struct ExtraData {
     ref_stack_max: c_int,
     ref_free: Vec<c_int>,
 
-    pub hook_callback: Option<Rc<Fn(&Debug) -> Result<()>>>,
-    // When this boolean is true, `Lua::execution_scope` will refuse to run to prevent recursion.
-    pub in_hook: AtomicBool
+    pub hook_callback: Option<Rc<Fn(&Debug) -> Result<()>>>
 }
 
 pub(crate) unsafe fn extra_data(state: *mut ffi::lua_State) -> *mut ExtraData {
@@ -1110,8 +1090,7 @@ unsafe fn create_lua(load_debug: bool) -> Lua {
         ref_stack_size: ffi::LUA_MINSTACK - 1,
         ref_stack_max: 0,
         ref_free: Vec::new(),
-        hook_callback: None,
-        in_hook: AtomicBool::new(false)
+        hook_callback: None
     }));
     *(ffi::lua_getextraspace(state) as *mut *mut ExtraData) = extra;
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -652,7 +652,8 @@ impl Lua {
     ///
     /// ```
     /// # extern crate rlua;
-    /// # use rlua::{Lua, HookTriggers, Debug};
+    /// # use rlua::{Lua, HookTriggers};
+    /// # use rlua::hook::Debug;
     /// # fn main() {
     /// let code = r#"local x = 2 + 3
     /// local y = x * 63

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -661,7 +661,7 @@ impl Lua {
     /// let lua = Lua::new();
     /// lua.set_hook(HookTriggers {
     ///     every_line: true, ..Default::default()
-    /// }, |_lua: Lua, debug: &Debug| {
+    /// }, |_lua: &Lua, debug: &Debug| {
     ///     println!("line {}", debug.curr_line);
     ///     Ok(())
     /// });
@@ -673,7 +673,7 @@ impl Lua {
         triggers: HookTriggers,
         callback: F)
     where
-        F: 'static + Send + FnMut(Lua, &Debug) -> Result<()>
+        F: 'static + Send + FnMut(&Lua, &Debug) -> Result<()>
     {
         unsafe {
             (*extra_data(self.state)).hook_callback = Some(Rc::new(RefCell::new(callback)));
@@ -995,7 +995,7 @@ pub(crate) struct ExtraData {
     ref_stack_max: c_int,
     ref_free: Vec<c_int>,
 
-    pub hook_callback: Option<Rc<RefCell<FnMut(Lua, &Debug) -> Result<()>>>>
+    pub hook_callback: Option<Rc<RefCell<FnMut(&Lua, &Debug) -> Result<()>>>>
 }
 
 pub(crate) unsafe fn extra_data(state: *mut ffi::lua_State) -> *mut ExtraData {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -649,7 +649,7 @@ impl Lua {
     ///
     /// let lua = Lua::new();
     /// lua.set_hook(HookTriggers {
-    ///     each_line: true, ..Default::default()
+    ///     every_line: true, ..Default::default()
     /// }, |debug: &Debug| {
     ///     println!("line {}", debug.curr_line);
     ///     Ok(())

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -634,9 +634,26 @@ impl Lua {
     /// Shows each line of code being executed by the Lua interpreter.
     /// TODO: When finished.
     ///
-    pub fn set_hook<F>(&self, options: HookOptions, callback: F)
+    pub fn set_hook<F>(
+        &self,
+        options: HookOptions,
+        callback: F)
     where
         F: 'static + Send + Fn(&Debug) -> Result<()>
+    {
+        self.set_mut_hook(options, callback)
+    }
+
+    /// Sets a function for Lua the same way as [`set_hook`], but allows the use of a mutable
+    /// function. The behavior is the same otherwise.
+    ///
+    /// [`set_hook`]: #method.set_hook
+    pub fn set_mut_hook<F>(
+        &self,
+        options: HookOptions,
+        callback: F)
+    where
+        F: 'static + Send + FnMut(&Debug) -> Result<()>
     {
         unsafe {
             (*extra_data(self.state)).hook_callback = Some(Box::new(callback));
@@ -958,7 +975,7 @@ pub(crate) struct ExtraData {
     ref_stack_max: c_int,
     ref_free: Vec<c_int>,
 
-    pub hook_callback: Option<Box<Fn(&Debug) -> Result<()>>>
+    pub hook_callback: Option<Box<FnMut(&Debug) -> Result<()>>>
 }
 
 pub(crate) unsafe fn extra_data(state: *mut ffi::lua_State) -> *mut ExtraData {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -74,7 +74,8 @@ impl Lua {
     }
 
     /// Creates a new Lua state from a state already declared. It is assumed `state` is valid.
-    pub(crate) unsafe fn from_state(state: *mut ffi::lua_State) -> Lua {
+    /// this instance will not delete its state after being dropped.
+    pub(crate) unsafe fn make_ephemeral(state: *mut ffi::lua_State) -> Lua {
         Lua {
             state,
             main_state: main_state(state),
@@ -915,12 +916,7 @@ impl Lua {
                     check_stack(state, ffi::LUA_MINSTACK - nargs)?;
                 }
 
-                let lua = Lua {
-                    state: state,
-                    main_state: main_state(state),
-                    ephemeral: true,
-                    _phantom: PhantomData,
-                };
+                let lua = Lua::make_ephemeral(state);
 
                 let mut args = MultiValue::new();
                 args.reserve(nargs as usize);

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -74,13 +74,11 @@ impl Lua {
     }
 
     /// Creates a new Lua state from a state already declared. It is assumed `state` is valid.
-    /// `owns`, if true, indicates `state` is not bound to another `Lua` structure, as opposed to
-    /// false, which will make the new structure act as a simple wrapper.
-    pub(crate) unsafe fn from_state(state: *mut ffi::lua_State, owns: bool) -> Lua {
+    pub(crate) unsafe fn from_state(state: *mut ffi::lua_State) -> Lua {
         Lua {
             state,
-            main_state: state,
-            ephemeral: !owns,
+            main_state: main_state(state),
+            ephemeral: true,
             _phantom: PhantomData
         }
     }

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -8,6 +8,7 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::string::String as StdString;
 use std::sync::{Arc, Mutex};
 use std::{mem, ptr, str};
+use std::sync::atomic::{Ordering, AtomicBool};
 
 use libc;
 
@@ -83,7 +84,7 @@ impl Lua {
     where
         S: ?Sized + AsRef<[u8]>,
     {
-        unsafe {
+        self.execution_scope(|| unsafe {
             let _sg = StackGuard::new(self.state);
             assert_stack(self.state, 1);
             let source = source.as_ref();
@@ -112,7 +113,7 @@ impl Lua {
                 ffi::LUA_OK => Ok(Function(self.pop_ref())),
                 err => Err(pop_error(self.state, err)),
             }
-        }
+        })
     }
 
     /// Execute a chunk of Lua code.
@@ -130,7 +131,7 @@ impl Lua {
         S: ?Sized + AsRef<[u8]>,
         R: FromLuaMulti<'lua>,
     {
-        self.load(source, name)?.call(())
+        self.execution_scope(|| self.load(source, name)?.call(()))
     }
 
     /// Evaluate the given expression or chunk inside this Lua state.
@@ -147,9 +148,11 @@ impl Lua {
         // actual lua repl does.
         let mut return_source = "return ".as_bytes().to_vec();
         return_source.extend(source.as_ref());
-        self.load(&return_source, name)
-            .or_else(|_| self.load(source, name))?
-            .call(())
+        self.execution_scope(||
+            self.load(&return_source, name)
+                .or_else(|_| self.load(source, name))?
+                .call(())
+        )
     }
 
     /// Create and return an interned Lua string.  Lua strings can be arbitrary [u8] data including
@@ -973,6 +976,21 @@ impl Lua {
 
         Ok(AnyUserData(self.pop_ref()))
     }
+
+    // Any code that desires to tell Lua to execute code should go through this function. It will
+    // panic if it is running within a hook.
+    fn execution_scope<F, R>(&self, proc: F) -> Result<R>
+    where
+        F: FnOnce() -> Result<R>,
+        R: Sized
+    {
+        let in_hook = (unsafe { &*extra_data(self.state) }).in_hook.load(Ordering::Relaxed);
+        if in_hook {
+            rlua_panic!("attempted to run code within a hook")
+        } else {
+            proc()
+        }
+    }
 }
 
 // Data associated with the main lua_State via lua_getextraspace.
@@ -985,7 +1003,9 @@ pub(crate) struct ExtraData {
     ref_stack_max: c_int,
     ref_free: Vec<c_int>,
 
-    pub hook_callback: Option<Rc<Fn(&Debug) -> Result<()>>>
+    pub hook_callback: Option<Rc<Fn(&Debug) -> Result<()>>>,
+    // When this boolean is true, `Lua::execution_scope` will refuse to run to prevent recursion.
+    pub in_hook: AtomicBool
 }
 
 pub(crate) unsafe fn extra_data(state: *mut ffi::lua_State) -> *mut ExtraData {
@@ -1090,7 +1110,8 @@ unsafe fn create_lua(load_debug: bool) -> Lua {
         ref_stack_size: ffi::LUA_MINSTACK - 1,
         ref_stack_max: 0,
         ref_free: Vec::new(),
-        hook_callback: None
+        hook_callback: None,
+        in_hook: AtomicBool::new(false)
     }));
     *(ffi::lua_getextraspace(state) as *mut *mut ExtraData) = extra;
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1,5 +1,6 @@
 use std::any::TypeId;
 use std::cell::{RefCell, UnsafeCell};
+use std::rc::Rc;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::marker::PhantomData;
@@ -662,10 +663,10 @@ impl Lua {
         triggers: HookTriggers,
         callback: F)
     where
-        F: 'static + Send + FnMut(&Debug) -> Result<()>
+        F: 'static + Send + Fn(&Debug) -> Result<()>
     {
         unsafe {
-            (*extra_data(self.state)).hook_callback = Some(Box::new(callback));
+            (*extra_data(self.state)).hook_callback = Some(Rc::new(callback));
             ffi::lua_sethook(self.state, Some(hook_proc), triggers.mask(), triggers.count());
         }
     }
@@ -984,7 +985,7 @@ pub(crate) struct ExtraData {
     ref_stack_max: c_int,
     ref_free: Vec<c_int>,
 
-    pub hook_callback: Option<Box<FnMut(&Debug) -> Result<()>>>
+    pub hook_callback: Option<Rc<Fn(&Debug) -> Result<()>>>
 }
 
 pub(crate) unsafe fn extra_data(state: *mut ffi::lua_State) -> *mut ExtraData {

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,5 +1,6 @@
 extern crate rlua;
 
+use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, TryRecvError};
 use std::ops::Deref;
 use std::time::{Instant, Duration};
@@ -107,3 +108,32 @@ fn hook_removal() {
     lua.remove_hook();
     assert!(lua.exec::<_, ()>(code, None).is_ok());
 }
+
+/* TODO: Will need to get readjusted.
+#[test]
+fn hook_swap_within_hook() {
+    let code = r#"
+        local x = 1
+        x = 2
+        local y = 3
+    "#.trim_left_matches("\r\n");
+    let lua = Lua::new();
+
+    lua.set_hook(HookTriggers {
+        every_line: true, ..Default::default()
+    }, |_debug| {
+        lua.globals().set("ok", 1i64);
+        lua.set_hook(HookTriggers {
+            every_line: true, ..Default::default()
+        }, |_debug| {
+            lua.globals().set("ok", 2i64);
+            lua.remove_hook();
+            Ok(())
+        });
+        Ok(())
+    });
+
+    assert!(lua.exec::<_, ()>(code, None).is_ok());
+    assert_eq!(lua.globals().get::<_, i64>("ok").unwrap_or(-1), 2);
+}
+*/

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,0 +1,27 @@
+extern crate rlua;
+
+use std::sync::mpsc::{channel, TryRecvError};
+use rlua::{Lua, HookOptions};
+
+#[test]
+fn line_counts() {
+    let code = r#"local x = 2 + 3
+    local y = x * 63
+    print(x..", "..y)
+    "#;
+
+    let (sx, rx) = channel();
+    let lua = Lua::new();
+    lua.set_mut_hook(HookOptions {
+        lines: true, ..Default::default()
+    }, move |debug| {
+        let _ = sx.send(debug.curr_line);
+        Ok(())
+    });
+    let _: () = lua.exec(code, None).expect("exec error");
+
+    assert_eq!(rx.try_recv(), Ok(1));
+    assert_eq!(rx.try_recv(), Ok(2));
+    assert_eq!(rx.try_recv(), Ok(3));
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,20 +1,20 @@
 extern crate rlua;
 
 use std::sync::mpsc::{channel, TryRecvError};
-use rlua::{Lua, HookOptions};
+use rlua::{Lua, Debug, HookOptions};
 
 #[test]
 fn line_counts() {
     let code = r#"local x = 2 + 3
     local y = x * 63
-    print(x..", "..y)
+    local z = string.len(x..", "..y)
     "#;
 
     let (sx, rx) = channel();
     let lua = Lua::new();
     lua.set_mut_hook(HookOptions {
         lines: true, ..Default::default()
-    }, move |debug| {
+    }, move |debug: &Debug| {
         let _ = sx.send(debug.curr_line);
         Ok(())
     });

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -69,9 +69,9 @@ fn error_within_hook() {
 #[test]
 fn limit_execution_time() {
     let code = r#"
-    while true do
-        x = x + 1
-    end
+        while true do
+            x = x + 1
+        end
     "#;
     let start = Instant::now();
 

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,7 +1,8 @@
 extern crate rlua;
 
 use std::sync::mpsc::{channel, TryRecvError};
-use rlua::{Lua, Debug, HookOptions};
+use std::ops::Deref;
+use rlua::{Lua, Debug, HookOptions, Error};
 
 #[test]
 fn line_counts() {
@@ -24,4 +25,41 @@ fn line_counts() {
     assert_eq!(rx.try_recv(), Ok(2));
     assert_eq!(rx.try_recv(), Ok(3));
     assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+}
+
+#[test]
+fn function_calls() {
+    let code = r#"local v = string.len("Hello World")"#;
+
+    let (sx, rx) = channel();
+    let lua = Lua::new();
+    lua.set_mut_hook(HookOptions {
+        calls: true, ..Default::default()
+    }, move |debug: &Debug| {
+        let _ = sx.send(debug.to_owned());
+        Ok(())
+    });
+    let _: () = lua.exec(code, None).expect("exec error");
+
+    assert_eq!(rx.recv().unwrap().what.as_ref().unwrap().as_ref(), "main");
+    assert_eq!(rx.recv().unwrap().name.as_ref().unwrap().as_ref(), "len");
+}
+
+#[test]
+fn error_within_hook() {
+    let lua = Lua::new();
+    lua.set_mut_hook(HookOptions {
+        lines: true, ..Default::default()
+    }, move |_debug: &Debug| {
+        Err(Error::RuntimeError("Something happened in there!".to_string()))
+    });
+
+    let err = lua.exec::<_, ()>("x = 1", None).expect_err("panic didn't propagate");
+    match err {
+        Error::CallbackError { cause, .. } => match cause.deref() {
+            Error::RuntimeError(s) => assert_eq!(s, "Something happened in there!"),
+            _ => panic!("wrong callback error kind caught")
+        },
+        _ => panic!("wrong error kind caught")
+    }
 }

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -3,7 +3,8 @@ extern crate rlua;
 use std::sync::mpsc::{channel, TryRecvError};
 use std::ops::Deref;
 use std::time::{Instant, Duration};
-use rlua::{Lua, Debug, HookTriggers, Error, Value};
+use rlua::{Lua, Error, Value};
+use rlua::hook::{Debug, HookTriggers};
 
 #[test]
 fn line_counts() {

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -16,7 +16,7 @@ fn line_counts() {
     let (sx, rx) = channel();
     let lua = Lua::new();
     lua.set_hook(HookTriggers {
-        lines: true, ..Default::default()
+        each_line: true, ..Default::default()
     }, move |debug: &Debug| {
         let _ = sx.send(debug.curr_line);
         Ok(())
@@ -36,7 +36,7 @@ fn function_calls() {
     let (sx, rx) = channel();
     let lua = Lua::new();
     lua.set_hook(HookTriggers {
-        calls: true, ..Default::default()
+        on_calls: true, ..Default::default()
     }, move |debug: &Debug| {
         let _ = sx.send(debug.to_owned());
         Ok(())
@@ -51,7 +51,7 @@ fn function_calls() {
 fn error_within_hook() {
     let lua = Lua::new();
     lua.set_hook(HookTriggers {
-        lines: true, ..Default::default()
+        each_line: true, ..Default::default()
     }, |_debug: &Debug| {
         Err(Error::RuntimeError("Something happened in there!".to_string()))
     });
@@ -78,7 +78,7 @@ fn limit_execution_time() {
     let lua = Lua::new();
     let _ = lua.globals().set("x", Value::Integer(0));
     lua.set_hook(HookTriggers {
-        after_counts: Some(30), ..Default::default()
+        on_every_nth_instruction: Some(30), ..Default::default()
     }, move |_debug: &Debug| {
         if start.elapsed() >= Duration::from_millis(500) {
             Err(Error::RuntimeError("time's up".to_string()))
@@ -98,7 +98,7 @@ fn hook_removal() {
     let lua = Lua::new();
 
     lua.set_hook(HookTriggers {
-        after_counts: Some(1), ..Default::default()
+        on_every_nth_instruction: Some(1), ..Default::default()
     }, |_debug: &Debug| {
         Err(Error::RuntimeError("this hook should've been removed by this time".to_string()))
     });

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -120,11 +120,11 @@ fn hook_swap_within_hook() {
 
     lua.set_hook(HookTriggers {
         every_line: true, ..Default::default()
-    }, move |lua: Lua, _debug| {
+    }, move |lua: &Lua, _debug| {
         lua.globals().set("ok", 1i64).unwrap();
         lua.set_hook(HookTriggers {
             every_line: true, ..Default::default()
-        }, move |lua: Lua, _debug| {
+        }, move |lua: &Lua, _debug| {
             let _: () = lua.exec(inc_code, Some("hook_incrementer"))
                 .expect("exec failure within hook");
             lua.remove_hook();

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -108,7 +108,6 @@ fn hook_removal() {
     assert!(lua.exec::<_, ()>(code, None).is_ok());
 }
 
-/* TODO: Will need to get readjusted.
 #[test]
 fn hook_swap_within_hook() {
     let code = r#"
@@ -116,16 +115,18 @@ fn hook_swap_within_hook() {
         x = 2
         local y = 3
     "#.trim_left_matches("\r\n");
+    let inc_code = r#"if ok ~= nil then ok = ok + 1 end"#;
     let lua = Lua::new();
 
     lua.set_hook(HookTriggers {
         every_line: true, ..Default::default()
-    }, |_debug| {
+    }, move |lua, _debug| {
         lua.globals().set("ok", 1i64);
         lua.set_hook(HookTriggers {
             every_line: true, ..Default::default()
-        }, |_debug| {
-            lua.globals().set("ok", 2i64);
+        }, move |lua: Lua, _debug| {
+            let _: () = lua.exec(inc_code, Some("hook_incrementer"))
+                .expect("exec failure within hook");
             lua.remove_hook();
             Ok(())
         });
@@ -135,4 +136,4 @@ fn hook_swap_within_hook() {
     assert!(lua.exec::<_, ()>(code, None).is_ok());
     assert_eq!(lua.globals().get::<_, i64>("ok").unwrap_or(-1), 2);
 }
-*/
+

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -16,7 +16,7 @@ fn line_counts() {
     let (sx, rx) = channel();
     let lua = Lua::new();
     lua.set_hook(HookTriggers {
-        each_line: true, ..Default::default()
+        every_line: true, ..Default::default()
     }, move |debug: &Debug| {
         let _ = sx.send(debug.curr_line);
         Ok(())
@@ -51,7 +51,7 @@ fn function_calls() {
 fn error_within_hook() {
     let lua = Lua::new();
     lua.set_hook(HookTriggers {
-        each_line: true, ..Default::default()
+        every_line: true, ..Default::default()
     }, |_debug: &Debug| {
         Err(Error::RuntimeError("Something happened in there!".to_string()))
     });
@@ -78,7 +78,7 @@ fn limit_execution_time() {
     let lua = Lua::new();
     let _ = lua.globals().set("x", Value::Integer(0));
     lua.set_hook(HookTriggers {
-        on_every_nth_instruction: Some(30), ..Default::default()
+        every_nth_instruction: Some(30), ..Default::default()
     }, move |_debug: &Debug| {
         if start.elapsed() >= Duration::from_millis(500) {
             Err(Error::RuntimeError("time's up".to_string()))
@@ -98,7 +98,7 @@ fn hook_removal() {
     let lua = Lua::new();
 
     lua.set_hook(HookTriggers {
-        on_every_nth_instruction: Some(1), ..Default::default()
+        every_nth_instruction: Some(1), ..Default::default()
     }, |_debug: &Debug| {
         Err(Error::RuntimeError("this hook should've been removed by this time".to_string()))
     });

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -121,7 +121,7 @@ fn hook_swap_within_hook() {
     lua.set_hook(HookTriggers {
         every_line: true, ..Default::default()
     }, move |lua, _debug| {
-        lua.globals().set("ok", 1i64);
+        let _ = lua.globals().set("ok", 1i64);
         lua.set_hook(HookTriggers {
             every_line: true, ..Default::default()
         }, move |lua: Lua, _debug| {

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,6 +1,5 @@
 extern crate rlua;
 
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, TryRecvError};
 use std::ops::Deref;
 use std::time::{Instant, Duration};

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -18,7 +18,7 @@ fn line_counts() {
     lua.set_hook(HookTriggers {
         every_line: true, ..Default::default()
     }, move |_lua, debug: &Debug| {
-        let _ = sx.send(debug.curr_line);
+        sx.send(debug.curr_line).unwrap();
         Ok(())
     });
     let _: () = lua.exec(code, None).expect("exec error");
@@ -38,7 +38,7 @@ fn function_calls() {
     lua.set_hook(HookTriggers {
         on_calls: true, ..Default::default()
     }, move |_lua, debug: &Debug| {
-        let _ = sx.send(debug.to_owned());
+        sx.send(debug.to_owned()).unwrap();
         Ok(())
     });
     let _: () = lua.exec(code, None).expect("exec error");
@@ -76,7 +76,7 @@ fn limit_execution_time() {
     let start = Instant::now();
 
     let lua = Lua::new();
-    let _ = lua.globals().set("x", Value::Integer(0));
+    lua.globals().set("x", Value::Integer(0)).unwrap();
     lua.set_hook(HookTriggers {
         every_nth_instruction: Some(30), ..Default::default()
     }, move |_lua, _debug: &Debug| {
@@ -120,8 +120,8 @@ fn hook_swap_within_hook() {
 
     lua.set_hook(HookTriggers {
         every_line: true, ..Default::default()
-    }, move |lua, _debug| {
-        let _ = lua.globals().set("ok", 1i64);
+    }, move |lua: Lua, _debug| {
+        lua.globals().set("ok", 1i64).unwrap();
         lua.set_hook(HookTriggers {
             every_line: true, ..Default::default()
         }, move |lua: Lua, _debug| {

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -1,5 +1,6 @@
 extern crate rlua;
 
+use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, TryRecvError};
 use std::ops::Deref;
 use std::time::{Instant, Duration};


### PR DESCRIPTION
This PR adds three new functions and a few other types to safely wrap the `lua_sethook` function, as suggested by the issue https://github.com/kyren/rlua/issues/81.

This is my best attempt to make it possible to consult information for debugging purposes and to control script execution.

These functions have been written:
- `set_hook` and `set_mut_hook`: Sets a function to be called when the hook is raised. It gets the new `Debug` struct containing information related to the code and function (depending on the hook mask)
- `remove_hook`: Removes the hook previously set

A few new types such as `Debug` and `HookOptions`, written inside a new module, are used as parameters to those functions above. That module also contains a procedure given to `lua_sethook` used to call the Rust callback safely.

I regard this change as safe since it does not expose functions that changes the Lua stack or anything else (other than using the `Lua` structure itself). Moreover, since the hook can return a `Result`, it can terminate the execution of a script, as shown in a test, by returning the error back to the caller of `exec` and such. This satisfies the desire of the author as noted in the README.

Anyone is welcome to comment or suggest changes to make on my PR, since I did it without knowing too much about Lua's internal workings. I have not changed the README or version; I leave this to rlua's author discretion.

Thank you.