### PR TITLE
Update num-traits dependency to 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ system-lua = ["pkg-config"]
 [dependencies]
 libc = { version = "0.2" }
 failure = { version = "0.1.2" }
-num-traits = { version = "0.2" }
+num-traits = { version = "0.2.6" }
 compiletest_rs = { version = "0.3", optional = true }
 
 [build-dependencies]


### PR DESCRIPTION
This crate requires i128 support which is not
added to num-traits until the 0.2.5 release and i128
detection is added in 0.2.6.