### PR TITLE
fix typos on `util::error_traceback`

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -379,7 +379,7 @@ pub unsafe extern "C" fn error_traceback(state: *mut ffi::lua_State) -> c_int {
 
     if ffi::lua_checkstack(state, 2) == 0 {
         // If we don't have enough stack space to even check the error type, do nothing
-    } else if let Some(error) = get_wrapped_error(state, 1).as_ref() {
+    } else if let Some(error) = get_wrapped_error(state, -1).as_ref() {
         let traceback = if ffi::lua_checkstack(state, LUA_TRACEBACK_STACK) != 0 {
             gc_guard(state, || {
                 ffi::luaL_traceback(state, state, ptr::null(), 0);
@@ -403,10 +403,10 @@ pub unsafe extern "C" fn error_traceback(state: *mut ffi::lua_State) -> c_int {
                 cause: Arc::new(error),
             },
         );
-    } else if !is_wrapped_panic(state, 1) {
+    } else if !is_wrapped_panic(state, -1) {
         if ffi::lua_checkstack(state, LUA_TRACEBACK_STACK) != 0 {
             gc_guard(state, || {
-                let s = ffi::lua_tostring(state, 1);
+                let s = ffi::lua_tostring(state, -1);
                 let s = if s.is_null() {
                     cstr!("<unprintable lua error>")
                 } else {


### PR DESCRIPTION
the comment of the function says it 'Takes an error at the top of the stack'
but it actually checks 1 instead of -1 (an offset pointing at the top of the stack).
this commit also fixes the VM yielding `<unprintable lua error>` (due to wrong offset)
when the error(s) happened inside coroutines.

code:

```rust
extern crate rlua; // version 0.15.4-alpha.0

use rlua::Lua;

fn main() {
    Lua::new().context(|lua| {
        let result = lua.eval::<_, ()>(r##"
function foo()
  if 2 > true then
    print("hello!")
  end
end
foo()
"##, None);

        // it displays the error with traceback.
        match result {
            Ok(_) => (),
            Err(e) => println!("{:?}", e),
        }

        let thread = lua.eval::<_, rlua::Thread>(r##"
coroutine.create(function()
  if 2 > true then
    print("hello!")
    coroutine.yield()
  end
end)
"##, None).unwrap();
        let result = thread.resume::<_, ()>(());

        // it displays <unprintable lua error> instead.
        match result {
            Ok(_) => (),
            Err(e) => println!("{:?}", e),
        }
    });
}
```

output:

```
RuntimeError("[string \"?\"]:3: attempt to compare boolean with number\nstack traceback:\n\t[C]: in metamethod \'__lt\'\n\t[string \"?\"]:3: in function \'foo\'\n\t[string \"?\"]:7: in main chunk")
RuntimeError("<unprintable lua error>\nstack traceback:\n\t[string \"?\"]:3: in function <[string \"?\"]:2>")
```
