### PR TITLE
Allows loading specific lua modules.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ system-lua = ["pkg-config"]
 libc = { version = "0.2" }
 failure = { version = "0.1.2" }
 num-traits = { version = "0.2.6" }
+bitflags = { version = "1.0.4" }
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@
 // warnings at all.
 #![doc(test(attr(deny(warnings))))]
 
+#[macro_use]
+extern crate bitflags;
+
 mod error;
 mod ffi;
 #[macro_use]
@@ -62,7 +65,7 @@ mod value;
 pub use crate::context::Context;
 pub use crate::error::{Error, ExternalError, ExternalResult, Result};
 pub use crate::function::Function;
-pub use crate::lua::Lua;
+pub use crate::lua::{Lua, LuaMod};
 pub use crate::multi::Variadic;
 pub use crate::scope::Scope;
 pub use crate::string::String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod value;
 pub use crate::context::Context;
 pub use crate::error::{Error, ExternalError, ExternalResult, Result};
 pub use crate::function::Function;
-pub use crate::lua::{Lua, LuaMod};
+pub use crate::lua::{Lua, StdLib};
 pub use crate::multi::Variadic;
 pub use crate::scope::Scope;
 pub use crate::string::String;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -92,12 +92,13 @@ impl Lua {
         create_lua(LuaMod::ALL)
     }
 
-    /// Create a new Lua state and loads a subset of the standard libraries.
+    /// Creates a new Lua state and loads a subset of the standard libraries.
     ///
     /// Use the [`LuaMod`] flags to specifiy the libraries you want to load.
     ///
-    /// Note that you the `debug` library can't be loaded using this function as it breaks all the
-    /// safety guarantees. If you really want to load it, use the sister function [`Lua::unsafe_new_with`].
+    /// Note that the `debug` library can't be loaded using this function as it breaks all the
+    /// safety guarantees. If you really want to load it, use the sister function
+    /// [`Lua::unsafe_new_with`].
     pub fn new_with(mut lua_mod: LuaMod) -> Lua {
         // Force disable the `debug` module to prevent unsafety.
         lua_mod.set(LuaMod::DEBUG, false);
@@ -105,7 +106,7 @@ impl Lua {
         unsafe { create_lua(lua_mod) }
     }
 
-    /// Create a new Lua state and loads a subset of the standard libraries.
+    /// Creates a new Lua state and loads a subset of the standard libraries.
     ///
     /// Use the [`LuaMod`] flags to specifiy the libraries you want to load.
     ///

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -99,9 +99,9 @@ impl Lua {
     /// Note that the `debug` library can't be loaded using this function as it breaks all the
     /// safety guarantees. If you really want to load it, use the sister function
     /// [`Lua::unsafe_new_with`].
-    pub fn new_with(mut lua_mod: LuaMod) -> Lua {
-        // Force disable the `debug` module to prevent unsafety.
-        lua_mod.set(LuaMod::DEBUG, false);
+    pub fn new_with(lua_mod: LuaMod) -> Lua {
+        assert!(!lua_mod.contains(LuaMod::DEBUG), "The lua debug module can't be loaded using `new_with`. \
+                                                   Use `unsafe_new_with` instead.");
 
         unsafe { create_lua(lua_mod) }
     }

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -216,52 +216,49 @@ unsafe fn create_lua(lua_mod_to_load: LuaMod) -> Lua {
 
     let ref_thread = rlua_expect!(
         protect_lua_closure(state, 0, 0, |state| {
-            let mut pop_size = 0;
             // Do not open the debug library, it can be used to cause unsafety.
             if lua_mod_to_load.contains(LuaMod::BASE) {
                 ffi::luaL_requiref(state, cstr!("_G"), ffi::luaopen_base, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::COROUTINE) {
                 ffi::luaL_requiref(state, cstr!("coroutine"), ffi::luaopen_coroutine, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::TABLE) {
                 ffi::luaL_requiref(state, cstr!("table"), ffi::luaopen_table, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::IO) {
                 ffi::luaL_requiref(state, cstr!("io"), ffi::luaopen_io, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::OS) {
                 ffi::luaL_requiref(state, cstr!("os"), ffi::luaopen_os, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::STRING) {
                 ffi::luaL_requiref(state, cstr!("string"), ffi::luaopen_string, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::UTF8) {
                 ffi::luaL_requiref(state, cstr!("utf8"), ffi::luaopen_utf8, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::MATH) {
                 ffi::luaL_requiref(state, cstr!("math"), ffi::luaopen_math, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
             if lua_mod_to_load.contains(LuaMod::PACKAGE) {
                 ffi::luaL_requiref(state, cstr!("package"), ffi::luaopen_package, 1);
-                pop_size += 1;
+                ffi::lua_pop(state, 1);
             }
-            ffi::lua_pop(state, pop_size);
-
-            init_error_metatables(state);
-
             if lua_mod_to_load.contains(LuaMod::DEBUG) {
                 ffi::luaL_requiref(state, cstr!("debug"), ffi::luaopen_debug, 1);
                 ffi::lua_pop(state, 1);
             }
+
+            init_error_metatables(state);
 
             // Create the function metatable
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -100,8 +100,10 @@ impl Lua {
     /// safety guarantees. If you really want to load it, use the sister function
     /// [`Lua::unsafe_new_with`].
     pub fn new_with(lua_mod: LuaMod) -> Lua {
-        assert!(!lua_mod.contains(LuaMod::DEBUG), "The lua debug module can't be loaded using `new_with`. \
-                                                   Use `unsafe_new_with` instead.");
+        assert!(
+            !lua_mod.contains(LuaMod::DEBUG),
+            "The lua debug module can't be loaded using `new_with`. Use `unsafe_new_with` instead."
+        );
 
         unsafe { create_lua(lua_mod) }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,7 +5,7 @@ use std::{error, f32, f64, fmt};
 
 use failure::err_msg;
 use rlua::{
-    Error, ExternalError, Function, Lua, LuaMod, Nil, Result, String, Table, UserData, Value,
+    Error, ExternalError, Function, Lua, Nil, Result, StdLib, String, Table, UserData, Value,
     Variadic,
 };
 
@@ -39,7 +39,7 @@ fn test_debug() {
 #[test]
 #[should_panic]
 fn test_new_with_debug_panic() {
-    let _lua = Lua::new_with(LuaMod::DEBUG);
+    let _lua = Lua::new_with(StdLib::DEBUG);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,8 +5,8 @@ use std::{error, f32, f64, fmt};
 
 use failure::err_msg;
 use rlua::{
-    Error, ExternalError, Function, Lua, Nil, Result, String, Table, UserData, Value, Variadic,
-    LuaMod
+    Error, ExternalError, Function, Lua, LuaMod, Nil, Result, String, Table, UserData, Value,
+    Variadic,
 };
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,6 +6,7 @@ use std::{error, f32, f64, fmt};
 use failure::err_msg;
 use rlua::{
     Error, ExternalError, Function, Lua, Nil, Result, String, Table, UserData, Value, Variadic,
+    LuaMod
 };
 
 #[test]
@@ -33,6 +34,12 @@ fn test_debug() {
             "stack traceback:".into()
         );
     });
+}
+
+#[test]
+#[should_panic]
+fn test_new_with_debug_panic() {
+    let _lua = Lua::new_with(LuaMod::DEBUG);
 }
 
 #[test]


### PR DESCRIPTION
Modify the public API to allow the user to load specified subset of the
standard library rather than all the lua standard library. This commit adds 2
new creators to the `Lua` struct:
- A safe `new_with` that force-disable the `debug` library.
- An unsafe `unsafe_new_with` that allows to do everything you want, but does
  not provide any safety guarantees.

Close #51 