### PR TITLE
[RFC] add ToLua and FromLua implementations for serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,13 @@ builtin-lua = ["cc"]
 # the final binary manually.  The builtin-lua and system-lua features are
 # mutually exclusive and enabling both will cause an error at build time.
 system-lua = ["pkg-config"]
+json = ["serde_json"]
 
 [dependencies]
 libc = { version = "0.2" }
 num-traits = { version = "0.2.6" }
 bitflags = { version = "1.0.4" }
+serde_json = { version = "1.0", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,108 @@
+use crate::context::Context;
+use crate::error::Error;
+use crate::error::Result;
+use crate::string::String;
+use crate::value::{FromLua, Nil, ToLua, Value};
+
+use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue};
+
+impl<'lua> ToLua<'lua> for &JsonValue {
+    fn to_lua(self, lua: Context<'lua>) -> Result<Value<'lua>> {
+        Ok(match self {
+            JsonValue::Null => Value::Nil,
+            JsonValue::Bool(b) => Value::Boolean(*b),
+            JsonValue::Number(n) => {
+                if let Some(n) = n.as_i64() {
+                    Value::Integer(n)
+                } else if let Some(n) = n.as_f64() {
+                    Value::Number(n)
+                } else {
+                    Err(Error::ToLuaConversionError {
+                        from: "serde_json::Number",
+                        to: "Integer",
+                        message: Some(format!("value {} too large", n)),
+                    })?
+                }
+            }
+            JsonValue::String(s) => lua.create_string(s).map(Value::String)?,
+            JsonValue::Array(values) => Value::Table(lua.create_sequence_from(values.iter())?),
+            JsonValue::Object(items) => {
+                let table = lua.create_table()?;
+
+                for (key, value) in items {
+                    let key = lua.create_string(key)?;
+                    table.set(key, value)?;
+                }
+
+                Value::Table(table)
+            }
+        })
+    }
+}
+
+impl<'lua> FromLua<'lua> for JsonValue {
+    fn from_lua(lua_value: Value<'lua>, lua: Context<'lua>) -> Result<Self> {
+        Ok(match lua_value {
+            Value::Nil => JsonValue::Null,
+            Value::Boolean(b) => JsonValue::Bool(b),
+            Value::LightUserData(_) => Err(Error::FromLuaConversionError {
+                from: "LightUserData",
+                to: "serde_json::Value",
+                message: Some("not supported".to_string()),
+            })?,
+            Value::Integer(i) => JsonValue::Number(i.into()),
+            Value::Number(n) => JsonValue::Number(JsonNumber::from_f64(n).ok_or_else(|| {
+                Error::FromLuaConversionError {
+                    from: "Number",
+                    to: "serde_json::Number",
+                    message: Some(format!("value {} not supported", n)),
+                }
+            })?),
+            Value::String(s) => JsonValue::String(s.to_str()?.to_string()),
+            Value::Table(t) => {
+                if t.len()? == 0 {
+                    // There's no way to know whether it's supposed to be an
+                    // object or an array.
+                    JsonValue::Object(JsonMap::new())
+                } else if let Ok(Nil) = t.get(1) {
+                    // It's probably a sequence.
+                    let values = t
+                        .sequence_values()
+                        .map(|r: Result<Value>| r.and_then(|v| JsonValue::from_lua(v, lua)))
+                        .collect::<Result<_>>()?;
+
+                    JsonValue::Array(values)
+                } else {
+                    // XXX: maybe call a metamethod here?
+                    let items = t
+                        .pairs()
+                        .map(|r: Result<(String, Value)>| {
+                            r.and_then(|(k, v)| {
+                                Ok((k.to_str()?.to_string(), JsonValue::from_lua(v, lua)?))
+                            })
+                        })
+                        .collect::<Result<_>>()?;
+
+                    JsonValue::Object(items)
+                }
+            }
+            Value::Function(_) => Err(Error::FromLuaConversionError {
+                from: "Function",
+                to: "serde_json::Value",
+                message: Some("not supported".to_string()),
+            })?,
+            Value::Thread(_) => Err(Error::FromLuaConversionError {
+                from: "Thread",
+                to: "serde_json::Value",
+                message: Some("not supported".to_string()),
+            })?,
+
+            Value::UserData(_) => Err(Error::FromLuaConversionError {
+                from: "AnyUserData",
+                to: "serde_json::Value",
+                message: Some("not supported".to_string()),
+            })?,
+            Value::Error(e) => Err(e)?,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ mod error;
 mod ffi;
 mod function;
 mod hook;
+#[cfg(feature = "json")]
+mod json;
 mod lua;
 mod markers;
 mod multi;

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,22 @@
+#![cfg(feature = "json")]
+
+use rlua::{FromLua as _, Lua, ToLua as _, Value};
+use serde_json::{json, Value as JsonValue};
+
+#[test]
+fn test_to_nil() {
+    Lua::new().context(|lua| match json!(null).to_lua(lua) {
+        Ok(Value::Nil) => (),
+        Ok(x) => panic!("unexpected conversion result: {:?}", x),
+        Err(e) => panic!("conversion error: {}", e),
+    });
+}
+
+#[test]
+fn test_from_nil() {
+    Lua::new().context(|lua| match JsonValue::from_lua(Value::Nil, lua) {
+        Ok(JsonValue::Null) => (),
+        Ok(x) => panic!("unexpected conversion result: {:?}", x),
+        Err(e) => panic!("conversion error: {}", e),
+    })
+}

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -58,7 +58,7 @@ fn string_views() {
 
         assert_eq!(empty.to_str().unwrap(), "");
         assert_eq!(empty.as_bytes_with_nul(), &[0]);
-        assert_eq!(empty.as_bytes(), &[]);
+        assert_eq!(empty.as_bytes(), b"");
     });
 }
 

--- a/tests/table.rs
+++ b/tests/table.rs
@@ -72,7 +72,7 @@ fn test_table() {
                 .sequence_values()
                 .collect::<Result<Vec<i64>>>()
                 .unwrap(),
-            vec![]
+            Vec::<i64>::new(),
         );
 
         // sequence_values should only iterate until the first border


### PR DESCRIPTION
This allows passing `serde_json::Value` objects to Lua and returning them.  This serves as a simple bridge between `serde` and `rlua` in cases where the trade-off of going through JSON is acceptable, e.g. when using Lua as a text templating language.

There's currently only a hint of a test.  If the feature itself and the implementation strategy is acceptable I'll try to cover everything with tests.

It might be nice to implement conversions from `serde::Serialize` and to `serde::Deserialize` directly.
Unfortunately, at least to me this looks quite daunting.  I might attempt it later.