### PR TITLE
add `load_from_std_lib` function to `Lua` state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ cc = { version = "1.0", optional = true }
 pkg-config = { version = "0.3.11", optional = true }
 
 [dev-dependencies]
-rustyline = "3.0.0"
+rustyline = "5.0"
 criterion = "0.2.0"
 compiletest_rs = { version = "0.3", features = ["stable"] }
 

--- a/tests/compile-fail/scope_invariance.rs
+++ b/tests/compile-fail/scope_invariance.rs
@@ -14,8 +14,8 @@ fn main() {
 
                 scope
                     .create_function_mut(|_, ()| {
+                        //~^ error: closure may outlive the current function, but it borrows `test`, which is owned by the current function
                         test.field = 42;
-                        //~^ error: `test` does not live long enough
                         Ok(())
                     })
                     .unwrap()

--- a/tests/compile-fail/scope_mutable_aliasing.rs
+++ b/tests/compile-fail/scope_mutable_aliasing.rs
@@ -12,7 +12,7 @@ fn main() {
         lua.scope(|scope| {
             let a = scope.create_nonstatic_userdata(MyUserData(&mut i)).unwrap();
             let b = scope.create_nonstatic_userdata(MyUserData(&mut i)).unwrap();
-            //~^ error: cannot borrow `*i` as mutable more than once at a time
+            //~^ error: cannot borrow `i` as mutable more than once at a time
         });
     });
 }


### PR DESCRIPTION
This function allows loading of any portion of the standard libraries
after initial state creation.

Specifically, this is filling a need to load the debug library after an
error is encountered so that a traceback can be generated without
risking exposing the debug library anywhere else in the code.