### PR TITLE
Improve error message from CallbackError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -182,8 +182,8 @@ impl fmt::Display for Error {
             Error::MismatchedRegistryKey => {
                 write!(fmt, "RegistryKey used from different Lua state")
             }
-            Error::CallbackError { ref traceback, .. } => {
-                write!(fmt, "callback error: {}", traceback)
+            Error::CallbackError { ref traceback, ref cause } => {
+                write!(fmt, "callback error: {}: {}", cause, traceback)
             }
             Error::ExternalError(ref err) => write!(fmt, "external error: {}", err),
         }


### PR DESCRIPTION
I got a bug report from a user on my project that uses rlua that the error messages they were getting didn't include the actual error:

https://github.com/rojo-rbx/remodel/issues/7

It turns out `CallbackError` doesn't show its inner error in its `Display` implementation. Is this an appropriate way to signal the inner error in rlua?