### PR TITLE
Make `Value::type_name` public

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -58,7 +58,8 @@ impl<'lua> Value<'lua> {
             Value::Table(_) => "table",
             Value::Function(_) => "function",
             Value::Thread(_) => "thread",
-            Value::UserData(_) | Value::Error(_) => "userdata",
+            Value::UserData(_) => "userdata",
+            Value::Error(_) => "error",
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -47,7 +47,7 @@ pub enum Value<'lua> {
 pub use self::Value::Nil;
 
 impl<'lua> Value<'lua> {
-    pub(crate) fn type_name(&self) -> &'static str {
+    pub fn type_name(&self) -> &'static str {
         match *self {
             Value::Nil => "nil",
             Value::Boolean(_) => "boolean",

--- a/src/value.rs
+++ b/src/value.rs
@@ -51,7 +51,7 @@ impl<'lua> Value<'lua> {
         match *self {
             Value::Nil => "nil",
             Value::Boolean(_) => "boolean",
-            Value::LightUserData(_) => "light userdata",
+            Value::LightUserData(_) => "lightuserdata",
             Value::Integer(_) => "integer",
             Value::Number(_) => "number",
             Value::String(_) => "string",


### PR DESCRIPTION
Please make `Value::type_name()` method public.

It would be of great help for users who implement [`FromLua`](https://docs.rs/rlua/0.17.0/rlua/trait.FromLua.html) trait for their custom Rust types and need to create an instance of [`FromLuaConversionError`](https://docs.rs/rlua/0.17.0/rlua/enum.Error.html#variant.FromLuaConversionError) for all of unsupported Lua types at once.