### PR TITLE
Update CallbackError and ExternalError Display impl to match recommendations

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -182,10 +182,10 @@ impl fmt::Display for Error {
             Error::MismatchedRegistryKey => {
                 write!(fmt, "RegistryKey used from different Lua state")
             }
-            Error::CallbackError { ref traceback, ref cause } => {
-                write!(fmt, "callback error: {}: {}", cause, traceback)
+            Error::CallbackError { ref traceback, .. } => {
+                write!(fmt, "callback error: {}", traceback)
             }
-            Error::ExternalError(ref err) => write!(fmt, "external error: {}", err),
+            Error::ExternalError(ref err) => write!(fmt, "{}", err),
         }
     }
 }
@@ -194,7 +194,7 @@ impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::CallbackError { ref cause, .. } => Some(cause.as_ref()),
-            Error::ExternalError(ref err) => Some(err.as_ref()),
+            Error::ExternalError(ref err) => err.source(),
             _ => None,
         }
     }


### PR DESCRIPTION
I've learned a fair bit more about Rust error handling since I opened #147. I believe I was now wrong in pushing for the error source being printed in the error's `Display` impl. I'm now trying to correct this in my own projects and projects that I have contributed to in the past. :sweat_smile:

As far as I know, doing "source-chasing" is the responsibility of the code that's printing an error. I think the correct way to handle `CallbackError` and `ExternalError` is as follows:

1. `ExternalError` should forward both `source()` and `Display::fmt` through to the underlying error type. This is what `#[error(transparent)]` does in [thiserror](https://docs.rs/thiserror/1.0.11/thiserror/), but it's easy to do by hand as well.
2. `CallbackError` should do what it did before I filed this PR.

With both of these changes, I think rlua will fit in slightly better into Rust's error ecosystem.